### PR TITLE
fix: move misplaced include (preventing compilation)

### DIFF
--- a/typical-value.c
+++ b/typical-value.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdio.h>
 #include "typical-value.h"
 #include "util.h"
 
@@ -21,7 +22,6 @@ init_array_to(int *array, size_t size, int value)
 void
 print(const SuggestedWidthStats *sws)
 {
-#include <stdio.h>
   for (int i = 0; i < sws->max_lengths_above; i++) {
     for (int j = 0; j < sws->lengths_above[i]; j += 100)
       printf("-");


### PR DESCRIPTION
Make was complaining about 'nested functions '..' declared extern... Found out that stdio.h was misplaced and was causing the errors. Moving the include to the top has seemed to fix the issue.

![image](https://github.com/TheodoreAlenas/refactored-dmenu/assets/120114728/3d4f2de4-7ae3-4abe-856e-0f3a168cb649)
